### PR TITLE
docs(core): Add JSDOC comments for core classes and methods.

### DIFF
--- a/src/core/api/api.js
+++ b/src/core/api/api.js
@@ -4,6 +4,28 @@ function NativePromiseWrapper(resolve, reject) {
   return new window.Promise(resolve, reject);
 }
 
+/**
+ * @class InboxAPI
+ *
+ * Class which represents a specific Inbox web service. From here, it's possible to query for and
+ * construct InboxNamespace objects, which represent email addresses associated with an account.
+ *
+ * @param {object|string} optionsOrAppId An object containing configuration kes, or alternatively
+ *   a string containing the appId for communicating with the webservice.
+ *
+ * @param {string=} optionalBaseUrl A string containing the base URL for the Inbox web service. If
+ *   the optionsOrAppId parameter is an object, then this field is not necessary. If not specified,
+ *   the baseUrl will be "http://api.inboxapp.co/"
+ *
+ * @param {function=} optionalPromiseConstructor A function which, when called, returns an instance
+ *   of an ES6-compatible Promise. If unspecified, window.Promise is used. Note that the Promise
+ *   constructor must be callable without `new`, so for non-native Promises, one should specify a
+ *   wrapper which constructs the associated promise.
+ *
+ * @throws {TypeError} The InboxAPI constructor will throw under the circumstances that we have
+ *   no appId, no Promise implementation, or if any of the configuration parameters are not of
+ *   the appropriate type.
+ */
 function InboxAPI(optionsOrAppId, optionalBaseUrl, optionalPromiseConstructor) {
   var options;
   var len;

--- a/src/core/api/messages.js
+++ b/src/core/api/messages.js
@@ -1,3 +1,19 @@
+/**
+ * @class InboxMessage
+ *
+ * Class which represents a specific Message associated with a Thread.
+ *
+ * @param {InboxThread} thread The InboxThread object which this InboxMessage is to be
+ *   associated with.
+ *
+ * @param {Object} data The data associated with a given InboxThread. This data arrives from a
+ *   successful response from a server, and should always contain the expected properties. However,
+ *   it is necessary for the object to contain a property `id`.
+ *
+ * @throws {TypeError} The InboxThread constructor will throw under the circumstances that we have
+ *   no `id` property in the response, or if the response object is null or undefined,
+ *   or if the `thread` parameter is not an instance of InboxThread.
+ */
 function InboxMessage(thread, data) {
   var namespace;
   if (!(thread instanceof InboxThread)) {

--- a/src/core/api/namespace.js
+++ b/src/core/api/namespace.js
@@ -1,4 +1,16 @@
-// TODO: support caching.
+/**
+ * @method InboxAPI#namespaces
+ *
+ * Query for namespaces associated with the signed in Inbox account.
+ *
+ * @param {Array} optionalNamespaces An array of InboxNamespace objects to be updated with new data.
+ *   Specifying this parameter with a non-null value will remove items not found in the response from
+ *   the server, and will add new properties to the found items, and add new items from the response
+ *   which were not available previously.
+ *
+ * @returns {Promise} A Promise to be fulfilled or rejected with the processed response from the
+ *   server.
+ */
 InboxAPI.prototype.namespaces = function(optionalNamespaces) {
   var self = this;
   var _ = self._;
@@ -36,6 +48,18 @@ InboxAPI.prototype.namespaces = function(optionalNamespaces) {
   });
 };
 
+/**
+ * @method InboxAPI#namespace
+ *
+ * Query for a specific namespace (by ID)
+ *
+ * @param {string} namespaceId The base36 namespace identifier associated with the account.
+ *
+ * @returns {Promise} A Promise to be fulfilled or rejected with the processed response from the
+ *   server.
+ *
+ * @throws {TypeError} Thrown if no namespaceId is provided, or if namespaceId is not a string.
+ */
 InboxAPI.prototype.namespace = function(namespaceId) {
   var self = this;
   var _ = self._;
@@ -56,6 +80,21 @@ InboxAPI.prototype.namespace = function(namespaceId) {
   });
 };
 
+/**
+ * @class InboxNamespace
+ *
+ * Class which represents a specific Namespace or email address on the Inbox web service
+ *
+ * @param {InboxAPI} inbox The InboxAPI object which this InboxNamespace is to be associated with.
+ *
+ * @param {Object} data The data associated with a given InboxNamespace. This data arrives from a
+ *   successful response from a server, and should always contain the expected properties. However,
+ *   it is necessary for the object to contain a property `id` or `namespace`.
+ *
+ * @throws {TypeError} The InboxNamespace constructor will throw under the circumstances that we have
+ *   no `id` or `namespace` properties in the response, or if the response object is null or undefined,
+ *   or if the `inbox` parameter is not an instance of InboxAPI.
+ */
 function InboxNamespace(inbox, data) {
   if (!(inbox instanceof InboxAPI)) {
     throw new TypeError("Cannot construct 'InboxNamespace': `inbox` parameter must be InboxAPI");

--- a/src/core/api/threads.js
+++ b/src/core/api/threads.js
@@ -1,3 +1,18 @@
+/**
+ * @method InboxNamespace#threads
+ *
+ * Query for threads associated with a particular namespace or email address.
+ *
+ * @param {Array|Object} optionalThreadsOrFilters If specified, and this object is an Array, it is
+ *   treated as an array of InboxThreads to update. Otherwise, if it is an Object, it is treated
+ *   as the filters parameter.
+ *
+ * @param {Object} filters An optional set of filters to be applied from the server, and narrow the
+ *   results of the operation.
+ *
+ * @returns {Promise} A Promise to be fulfilled or rejected with the processed response from the
+ *   server.
+ */
 InboxNamespace.prototype.threads = function(optionalThreadsOrFilters, filters) {
   var self = this;
   var _ = self._;
@@ -36,6 +51,18 @@ InboxNamespace.prototype.threads = function(optionalThreadsOrFilters, filters) {
   });
 };
 
+/**
+ * @method InboxNamespace#thread
+ *
+ * Query for threads associated with a particular namespace or email address.
+ *
+ * @param {string} threadId The base-36 thread ID to query for.
+ *
+ * @returns {Promise} A Promise to be fulfilled or rejected with the processed response from the
+ *   server.
+ *
+ * @throws {TypeError} This method will throw if `threadId` is not specified, or is not a string.
+ */
 InboxNamespace.prototype.thread = function(threadId) {
   var self = this;
   var _ = self._;
@@ -56,6 +83,22 @@ InboxNamespace.prototype.thread = function(threadId) {
   });
 };
 
+/**
+ * @class InboxThread
+ *
+ * Class which represents a specific Thread associated with a Namespace or Email address.
+ *
+ * @param {InboxNamespace} namespace The InboxNamespace object which this InboxThread is to be
+ *   associated with.
+ *
+ * @param {Object} data The data associated with a given InboxThread. This data arrives from a
+ *   successful response from a server, and should always contain the expected properties. However,
+ *   it is necessary for the object to contain a property `id`.
+ *
+ * @throws {TypeError} The InboxThread constructor will throw under the circumstances that we have
+ *   no `id` property in the response, or if the response object is null or undefined,
+ *   or if the `namespace` parameter is not an instance of InboxNamespace.
+ */
 function InboxThread(namespace, data) {
   if (!(namespace instanceof InboxNamespace)) {
     throw new TypeError("Cannot construct 'InboxThread': `inbox` parameter must be InboxNamespace");
@@ -87,9 +130,19 @@ function InboxThread(namespace, data) {
   DefineProperty(this, '_', INVISIBLE);
 }
 
-// TODO(@caitp): is `sync` a good name for this method? Do not want to confuse this with the
-// inboxapp concept of `sync`.
+
+/**
+ * @method InboxThread#sync
+ *
+ * Update a thread with new data from the server.
+ *
+ * @returns {Promise} A Promise to be fulfilled or rejected with the processed response from the
+ *   server. If the promise is fulfilled, the object will have the same identity as the original
+ *   InboxThread object, but will be merged with properties associated with InboxThread.
+ */
 InboxThread.prototype.sync = function() {
+  // TODO(@caitp): is `sync` a good name for this method? Do not want to confuse this with the
+  // inboxapp concept of `sync`.
   var self = this;
   var _ = self._;
   var inbox = _.inbox;
@@ -99,14 +152,32 @@ InboxThread.prototype.sync = function() {
   });
 };
 
-InboxThread.prototype.getMessages = function(updateMessages, filters) {
+/**
+ * @method InboxThread#getMessages
+ *
+ * Query for messages associated with the current Thread, optionally updating an array of existing
+ &   InboxMessages, and optionally filtered.
+ *
+ * @param {Array|Object} optionalMessagesOrFilters If specified, and this object is an Array, it is
+ *   treated as an array of InboxMessages to update. Otherwise, if it is an Object, it is treated
+ *   as the filters parameter.
+ *
+ * @param {Object} filters An optional set of filters to be applied from the server, and narrow the
+ *   results of the operation.
+ *
+ * @returns {Promise} A Promise to be fulfilled or rejected with the processed response from the
+ *   server.
+ */
+InboxThread.prototype.getMessages = function(optionalMessagesOrFilters, filters) {
+  // TODO(@caitp): rename this method --- This name is in use because `messages` shadows another
+  // property of the response, however we should do better.
   var url;
   var self = this;
   var namespace = self._.namespace;
 
-  if (!IsArray(updateMessages)) {
-    filters = updateMessages;
-    updateMessages = null;
+  if (!IsArray(optionalMessagesOrFilters)) {
+    filters = optionalMessagesOrFilters;
+    optionalMessagesOrFilters = null;
   }
 
   filters = (typeof filters === 'object' && filters) || {};
@@ -114,8 +185,8 @@ InboxThread.prototype.getMessages = function(updateMessages, filters) {
 
   url = URLFormat('%@/messages%@', namespace._.namespaceUrl, InboxURLFilters(filters));
   return XHR(self._.inbox, 'get', url, function(response) {
-    if (updateMessages) {
-      return MergeArray(updateMessages, response, 'id', function(data) {
+    if (optionalMessagesOrFilters) {
+      return MergeArray(optionalMessagesOrFilters, response, 'id', function(data) {
         return new InboxMessage(self, data);
       });
     } else {


### PR DESCRIPTION
Not perfect, and likely contains some mistakes, however it's likely a good
first attempt at documenting the JS SDK.
