### PR TITLE
feat(api) expose components to the outside world for testing

### DIFF
--- a/src/angular/module.js
+++ b/src/angular/module.js
@@ -42,6 +42,15 @@ angular.module('inbox', []).
       return this;
     };
 
+    this.InboxAPI = InboxAPI;
+    InboxAPI.INContact = INContact;
+    InboxAPI.INDraft = INDraft;
+    InboxAPI.INFile = INFile;
+    InboxAPI.INMessage = INMessage;
+    InboxAPI.INNamespace = INNamespace;
+    InboxAPI.INTag = INTag;
+    InboxAPI.INThread = INThread;
+
     this.$get = ['$q', function($q) {
       var tempConfig;
       var Promise = function(resolver) {


### PR DESCRIPTION
Exposes constructor functions for models by placing them within the
InboxAPI namespace.  Exposes the InboxAPI namespace to Angular via
$inboxProvider.  This allows tests to access the methods on these
objects.  A specific example is using INDraft.attachments() to ensure
that attachments have been added correctly and reflect the correct ID.
