### PR TITLE
feat(api) added INDraft#addAttachment

### DIFF
--- a/src/core/api/models/message_draft.js
+++ b/src/core/api/models/message_draft.js
@@ -163,6 +163,22 @@ INDraft.prototype.removeAttachment = function(file) {
   return this;
 };
 
+/**
+ * @function
+ * @name INDraft#addAttachment
+ *
+ * @description
+ * Adds an attachment which has already been uploaded to the server.
+ *
+ * @param {response} the response object returned by the API
+ */
+INDraft.prototype.addAttachment = function(file) {
+  if (!file || typeof file !== 'object' || !file.id) {
+    throw new TypeError(
+      'Cannot invoke `addAttachment` on INDraft: file must be an object with an ID');
+  }
+  this.fileData.push(file);
+};
 
 /**
  * Shadow INMessage#markAsRead method with 'null', because it is meaningless for draft messages.


### PR DESCRIPTION
Allows users to provide their own file upload mechanism and then tell INDraft about the server response.
